### PR TITLE
style: 홈 list로 이동 버튼 하단 위치 고정 #38

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -21,9 +21,9 @@ const Button = () => {
 
 const ButtonBox = styled.button`
   display: inline-block;
-  position: fixed;
-  bottom: 50px;
-  right: 60px;
+  position: sticky;
+  bottom: 70px;
+  left: calc(100% - 40px);
   width: ${({ theme }) => theme.fontSizes.big};
   height: ${({ theme }) => theme.fontSizes.big};
   margin: 0 auto;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Selected from '../components/Selected';
 import SearchInp from '../components/SearchInp';
 import styled from 'styled-components';
@@ -60,12 +60,13 @@ const Home = () => {
 };
 
 const Container = styled.div`
-  ${({ theme }) => theme.common.flexCenterColumn};
-  font-size: ${({ theme }) => theme.fontSizes.small};
   max-width: 800px;
+  height: 100vh;
   position: relative;
   padding: 2rem;
   margin: 0 auto;
+  box-sizing: border-box;
+  font-size: ${({ theme }) => theme.fontSizes.small};
   .item-list {
     margin-top: 30px;
     width: 100%;
@@ -93,11 +94,13 @@ const List = styled.li`
   padding: 1.7rem;
   border-radius: 5px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  overflow: auto;
   cursor: pointer;
   .cont {
     font-size: 1rem;
-    line-height: 1.5;
     .cont-txt {
+      vertical-align: 1px;
+      line-height: 1.8;
       margin-left: 8px;
     }
   }


### PR DESCRIPTION
fixed https://github.com/wanted-codestates-project-team-05/wanted-codestates-project-05-08/issues/38

-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[o] 스타일 수정

반영 브랜치
feat/lsy/home -> dev

변경 사항
list로 이동하는 버튼 하단으로 고정, 스크롤 시에도 위치 하단 유지